### PR TITLE
Update step.sh to fail when curl fails

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -49,7 +49,7 @@ echo "Downloading the remote script locally..."
 
 downloaded_script_path="$tmp_folder/remote-script.sh"
 
-curl -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail -H "Authorization: token $GITHUB_TOKEN" \
   -H 'Accept: application/vnd.github.v3.raw' \
   -sSL "https://api.github.com/repos/$repository/contents/$script_path?ref=$branch" &> $downloaded_script_path
 chmod +x $downloaded_script_path


### PR DESCRIPTION
[docs](https://everything.curl.dev/http/response#http-response-codes) - updated the script to fail on any status code >= 400 so we can catch things like 401,3 or 4.

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Cleanup

## :writing_hand: Ticket
<!-- XXX-123 (please insert correct ticket number and Jira automation will link to it automatically) -->

## :scroll: Description
<!-- Please describe your changes to help the reviewer. -->

## :test_tube: How did you test it?
- [ ] Tests already present
- [ ] Added automated tests
- [ ] Verified manually <!-- (Please specify which test cases you have roughly tried. This will be useful for the reviewer in order to suggest edge cases that may have been missed.) -->